### PR TITLE
saved 1 byte in dzx0_turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Afterwards you can choose a decompressor routine in assembly Z80, according to
 your requirements for speed and size:
 
 * "Standard" routine: 68 bytes only
-* "Turbo" routine: 126 bytes, about 21% faster
+* "Turbo" routine: 125 bytes, about 21% faster
 * "Fast" routine: 187 bytes, about 25% faster
 * "Mega" routine: 673 bytes, about 28% faster
 

--- a/z80/dzx0_turbo.asm
+++ b/z80/dzx0_turbo.asm
@@ -1,6 +1,6 @@
 ; -----------------------------------------------------------------------------
 ; ZX0 decoder by Einar Saukas & introspec
-; "Turbo" version (126 bytes, 21% faster)
+; "Turbo" version (125 bytes, 21% faster)
 ; -----------------------------------------------------------------------------
 ; Parameters:
 ;   HL: source address (compressed data)
@@ -11,8 +11,8 @@ dzx0_turbo:
         ld      bc, $ffff               ; preserve default offset 1
         ld      (dzx0t_last_offset+1), bc
         inc     bc
-        ld      a, $80
-        jr      dzx0t_literals
+        scf
+        jr      dzx0t_literals_start
 dzx0t_new_offset:
         ld      c, $fe                  ; prepare negative offset
         add     a, a
@@ -42,14 +42,14 @@ dzx0t_last_offset:
         pop     hl                      ; restore source
         add     a, a                    ; copy from literals or new offset?
         jr      c, dzx0t_new_offset
-dzx0t_literals:
-        inc     c                       ; obtain length
         add     a, a
         jp      nz, dzx0t_literals_skip
+dzx0t_literals_start:
         ld      a, (hl)                 ; load another group of 8 bits
         inc     hl
         rla
 dzx0t_literals_skip:
+        inc     c                       ; obtain length
         call    nc, dzx0t_elias
         ldir                            ; copy literals
         add     a, a                    ; copy from last offset or new offset?


### PR DESCRIPTION
I was able to save 1 byte in the `dzx0_turbo` routine from the optimizations pointed out here https://github.com/einar-saukas/ZX0/issues/32. Otherwise the speed is the exact same.

This 1 byte saving can also be applied to `dxz0_turbo_CLASSIC.asm`.

Similar optimizations could also be applied to `dzx0_fast` and `dzx0_turbo_back`, but they would not save any bytes.
